### PR TITLE
loo_cv() spell check

### DIFF
--- a/R/loo.R
+++ b/R/loo.R
@@ -1,6 +1,6 @@
 #' Leave-One-Out Cross-Validation
 #'
-#' Leave-one-out (LOO) cross-validation uses one data point in the original set as the assessment data and all other data points as the analysis set. A LOO resampling set has ass many resamples as rows in the original data set. 
+#' Leave-one-out (LOO) cross-validation uses one data point in the original set as the assessment data and all other data points as the analysis set. A LOO resampling set has as many resamples as rows in the original data set.
 #'
 #' @inheritParams vfold_cv
 #' @return  An tibble with classes `loo_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and one column called `id` that has a character string with the resample identifier.
@@ -10,18 +10,18 @@
 #' @export
 loo_cv <- function(data, ...) {
   split_objs <- vfold_splits(data = data, v = nrow(data))
-  split_objs <- 
+  split_objs <-
     list(splits = map(split_objs$splits, change_class),
          id = paste0("Resample", seq_along(split_objs$id)))
-  
-  ## We remove the holdout indicies since it will save space and we can 
-  ## derive them later when they are needed. 
-  
+
+  ## We remove the holdout indicies since it will save space and we can
+  ## derive them later when they are needed.
+
   split_objs$splits <- map(split_objs$splits, rm_out)
 
-  new_rset(splits = split_objs$splits, 
+  new_rset(splits = split_objs$splits,
            ids = split_objs$id,
-           subclass = c("loo_cv", "rset")) 
+           subclass = c("loo_cv", "rset"))
 }
 
 #' @export

--- a/man/loo_cv.Rd
+++ b/man/loo_cv.Rd
@@ -15,7 +15,7 @@ loo_cv(data, ...)
 An tibble with classes `loo_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and one column called `id` that has a character string with the resample identifier.
 }
 \description{
-Leave-one-out (LOO) cross-validation uses one data point in the original set as the assessment data and all other data points as the analysis set. A LOO resampling set has ass many resamples as rows in the original data set.
+Leave-one-out (LOO) cross-validation uses one data point in the original set as the assessment data and all other data points as the analysis set. A LOO resampling set has as many resamples as rows in the original data set.
 }
 \examples{
 loo_cv(mtcars)


### PR DESCRIPTION
Remove that `ass`.

It also trimmed some new line characters, I think. It happened automatically.
